### PR TITLE
Fix/simulation error when a node has not enough staked ETH

### DIFF
--- a/packages/hardhat/contracts/Staking/StakeBasedOracle.sol
+++ b/packages/hardhat/contracts/Staking/StakeBasedOracle.sol
@@ -52,7 +52,7 @@ contract StakeBasedOracle {
 
     function reportPrice(uint256 price) public {
         OracleNode storage node = nodes[msg.sender];
-        require(node.stakedAmount >= MINIMUM_STAKE, "Not a registered node");
+        require(node.stakedAmount >= MINIMUM_STAKE, "Not enough stake");
 
         node.lastReportedPrice = price;
         node.lastReportedTimestamp = block.timestamp;
@@ -67,11 +67,10 @@ contract StakeBasedOracle {
 
     function slashNode(address nodeToSlash, uint256 penalty) internal {
         OracleNode storage node = nodes[nodeToSlash];
+        uint256 actualPenalty = penalty > node.stakedAmount ? node.stakedAmount : penalty;
+        node.stakedAmount -= actualPenalty;
 
-        require(node.stakedAmount >= penalty, "Penalty exceeds stake");
-        node.stakedAmount -= penalty;
-
-        emit NodeSlashed(nodeToSlash, penalty);
+        emit NodeSlashed(nodeToSlash, actualPenalty);
     }
 
     function validateNodes() public {

--- a/packages/hardhat/deploy/01_deploy_staking.ts
+++ b/packages/hardhat/deploy/01_deploy_staking.ts
@@ -39,7 +39,7 @@ const deployStakingOracle: DeployFunction = async function (hre: HardhatRuntimeE
         abi: deployment.abi,
         functionName: "registerNode",
         args: [],
-        value: parseEther("50"),
+        value: parseEther("15"),
       });
     }),
   );

--- a/packages/hardhat/scripts/oracle-bot/reporting.ts
+++ b/packages/hardhat/scripts/oracle-bot/reporting.ts
@@ -1,4 +1,4 @@
-import { parseUnits } from "viem";
+import { parseUnits, PublicClient } from "viem";
 import { Config } from "./types";
 import { getRandomPrice } from "./price";
 import { HardhatRuntimeEnvironment } from "hardhat/types";
@@ -15,16 +15,42 @@ const getConfig = (): Config => {
   return config;
 };
 
+const getStakedAmount = async (publicClient: PublicClient, nodeAddress: `0x${string}`) => {
+  const nodeInfo = (await publicClient.readContract({
+    address,
+    abi,
+    functionName: "nodes",
+    args: [nodeAddress],
+  })) as any[];
+
+  const [, stakedAmount] = nodeInfo;
+  return stakedAmount as bigint;
+};
+
 export const reportPrices = async (hre: HardhatRuntimeEnvironment) => {
   const config = getConfig();
   const accounts = await hre.viem.getWalletClients();
   const oracleNodeAccounts = accounts.slice(1, 11);
+  const publicClient = await hre.viem.getPublicClient();
+
+  // Get minimum stake requirement from contract
+  const minimumStake = (await publicClient.readContract({
+    address,
+    abi,
+    functionName: "MINIMUM_STAKE",
+    args: [],
+  })) as bigint;
 
   try {
     return Promise.all(
       oracleNodeAccounts.map(async account => {
         const nodeConfig = config.NODE_CONFIGS[account.account.address] || config.NODE_CONFIGS.default;
         const shouldReport = Math.random() > nodeConfig.PROBABILITY_OF_SKIPPING_REPORT;
+        const stakedAmount = await getStakedAmount(publicClient, account.account.address);
+        if (stakedAmount < minimumStake) {
+          console.log(`Insufficient stake for ${account.account.address} for price reporting`);
+          return Promise.resolve();
+        }
 
         if (shouldReport) {
           const price = parseUnits(getRandomPrice(account.account.address).toString(), 6);

--- a/packages/nextjs/components/oracle/NodeRow.tsx
+++ b/packages/nextjs/components/oracle/NodeRow.tsx
@@ -18,6 +18,12 @@ export const NodeRow = ({ address }: NodeRowProps) => {
     args: [address],
   });
 
+  const { data: minimumStake } = useScaffoldReadContract({
+    contractName: "StakeBasedOracle",
+    functionName: "MINIMUM_STAKE",
+    args: undefined,
+  });
+
   const [_, stakedAmount, lastReportedPrice] = data;
 
   const stakedAmountFormatted = stakedAmount !== undefined ? formatEther(stakedAmount) : "Loading...";
@@ -25,8 +31,11 @@ export const NodeRow = ({ address }: NodeRowProps) => {
     lastReportedPrice !== undefined ? formatUnits(lastReportedPrice, 6) : "No price reported";
   const orcBalanceFormatted = orcBalance !== undefined ? formatEther(orcBalance) : "Loading...";
 
+  // Check if staked amount is below minimum requirement
+  const isInsufficientStake = stakedAmount !== undefined && minimumStake !== undefined && stakedAmount < minimumStake;
+
   return (
-    <tr>
+    <tr className={isInsufficientStake ? "bg-gray-300 opacity-50" : ""}>
       <td>
         <Address address={address} />
       </td>


### PR DESCRIPTION
Regarding #3,

In this PR, I fixed an error in simulation script, when the node has not enough stake to report the price. Also, in StakeBasedOracle.sol, I modified the error for the report price and slashnode function. It is not possible to validate the nodes, if one node doesn't have enough stake due to the require. The question is should we still slash the node, if the node doesn't have enough stake or we should slash the node until 0?

Modified frontend a bit to display the nodes, which are node contributing to the final price
<img width="1336" alt="image" src="https://github.com/user-attachments/assets/2c2052f3-46d4-42ae-a6e5-0fad5b17c248" />


Regarding #4,

I changed it to 15 ETH, because I think with 10 ETH, it will be too fast, what do you think?