### PR TITLE
feat: add whitelisted addressses via UI

### DIFF
--- a/packages/hardhat/contracts/SimpleOracle.sol
+++ b/packages/hardhat/contracts/SimpleOracle.sol
@@ -12,12 +12,10 @@ contract SimpleOracle {
         owner = _owner;
     }
 
-    modifier onlyOwner() {
-        require(msg.sender == owner, "Not the owner");
-        _;
-    }
-
-    function setPrice(uint256 _newPrice) public onlyOwner {
+    // Note: In a real oracle implementation, this function would typically have
+    // an onlyOwner modifier to restrict who can update prices. We've removed
+    // it here to make prices easily editable in the frontend.
+    function setPrice(uint256 _newPrice) public {
         price = _newPrice;
         timestamp = block.timestamp;
         emit PriceUpdated(_newPrice);

--- a/packages/hardhat/contracts/WhitelistOracle.sol
+++ b/packages/hardhat/contracts/WhitelistOracle.sol
@@ -76,4 +76,10 @@ contract WhitelistOracle {
 
         return median;
     }
+
+    function transferOwnership(address newOwner) public onlyOwner {
+        require(newOwner != address(0), "New owner cannot be zero address");
+        require(newOwner != owner, "New owner cannot be the same as current owner");
+        owner = newOwner;
+    }
 }

--- a/packages/hardhat/deploy/00_deploy_whitelist.ts
+++ b/packages/hardhat/deploy/00_deploy_whitelist.ts
@@ -15,6 +15,7 @@ const deployWhitelistOracleContracts: DeployFunction = async function (hre: Hard
   const publicClient = await viem.getPublicClient();
 
   console.log("Deploying WhitelistOracle contracts...");
+  const whitelistContractOwner = deployer;
 
   // Get 10 wallet clients (accounts)
   const accounts = await viem.getWalletClients();
@@ -93,6 +94,18 @@ const deployWhitelistOracleContracts: DeployFunction = async function (hre: Hard
     args: [],
   });
   console.log(`Initial median price: ${medianPrice.toString()}`);
+
+  if (deployer !== whitelistContractOwner) {
+    console.log("Transferring ownership of WhitelistOracle");
+    await deployerAccount.writeContract({
+      address: whitelistOracleAddress,
+      abi: whitelistOracleAbi,
+      functionName: "transferOwnership",
+      args: [whitelistContractOwner],
+    });
+    console.log("Ownership transferred successfully!");
+  }
+
   console.log("All oracle contracts deployed and configured successfully!");
 };
 

--- a/packages/nextjs/components/oracle/whitelist/AddOracleButton.tsx
+++ b/packages/nextjs/components/oracle/whitelist/AddOracleButton.tsx
@@ -1,0 +1,184 @@
+import { useState } from "react";
+import { Address as AddressType, parseEther } from "viem";
+import { generatePrivateKey, privateKeyToAccount } from "viem/accounts";
+import { useAccount, usePublicClient, useWalletClient } from "wagmi";
+import { PlusIcon } from "@heroicons/react/24/outline";
+import { AddressInput, IntegerInput } from "~~/components/scaffold-eth";
+import deployedContracts from "~~/contracts/deployedContracts";
+import { useScaffoldWriteContract } from "~~/hooks/scaffold-eth";
+import { getParsedError, notification } from "~~/utils/scaffold-eth";
+
+// SimpleOracle bytecode from compiled artifact
+const SIMPLE_ORACLE_BYTECODE =
+  "0x60a060405234801561001057600080fd5b5060405161020838038061020883398101604081905261002f91610040565b6001600160a01b0316608052610070565b60006020828403121561005257600080fd5b81516001600160a01b038116811461006957600080fd5b9392505050565b60805161017e61008a60003960006061015261017e6000f3fe608060405234801561001057600080fd5b50600436106100575760003560e01c80638da5cb5b1461005c57806391b7f5ed146100a057806398d5fdca146100b5578063a035b1fe146100d0578063b80777ea146100e7575b600080fd5b6100837f000000000000000000000000000000000000000000000000000000000000000081565b6040516001600160a01b0390911681526020015b60405180910390f35b6100b36100ae36600461012f565b6100f0565b005b60005460015460408051928352602083019190915201610097565b6100d960005481565b604051908152602001610097565b6100d960015481565b6000819055426001556040518181527f66cbca4f3c64fecf1dcb9ce094abcf7f68c3450a1d4e3a8e917dd621edb4ebe09060200160405180910390a150565b60006020828403121561014157600080fd5b503591905056fea26469706673582212209fd125d081658cebd290a96a912d32827a9dea9c1dbb9f2c5f9598dffd5fbbca64736f6c63430008140033" as const;
+
+export const AddOracleButton = () => {
+  const [newOracleOwner, setNewOracleOwner] = useState<AddressType>();
+  const [initialPrice, setInitialPrice] = useState("");
+  const [isDeploying, setIsDeploying] = useState(false);
+
+  const { address: connectedAddress } = useAccount();
+  const { data: walletClient } = useWalletClient();
+  const publicClient = usePublicClient();
+
+  const { writeContractAsync: writeWhitelistOracle } = useScaffoldWriteContract({ contractName: "WhitelistOracle" });
+
+  const handleGenerateRandomAddress = () => {
+    const privateKey = generatePrivateKey();
+    const account = privateKeyToAccount(privateKey);
+    setNewOracleOwner(account.address as AddressType);
+  };
+
+  const handleAddOracle = async () => {
+    if (!newOracleOwner || !walletClient || !connectedAddress || !publicClient || !initialPrice) {
+      notification.error("Please connect wallet and enter both oracle owner address and initial price");
+      return;
+    }
+    if (Number.isNaN(Number(initialPrice)) || Number(initialPrice) <= 0) {
+      notification.error("Please enter a valid initial price");
+      return;
+    }
+
+    try {
+      setIsDeploying(true);
+
+      // Step 1: Deploy new SimpleOracle instance
+
+      // Get SimpleOracle ABI from deployed contracts
+      const simpleOracleAbi = deployedContracts[31337].SimpleOracle_1.abi; // TODO: fix this. Maybe put it in a separate file as a constant.
+
+      const deployTxHash = await walletClient.deployContract({
+        abi: simpleOracleAbi,
+        bytecode: SIMPLE_ORACLE_BYTECODE,
+        args: [newOracleOwner],
+      });
+
+      // Wait for deployment transaction receipt
+      const receipt = await publicClient.waitForTransactionReceipt({
+        hash: deployTxHash,
+      });
+
+      const oracleAddress = receipt.contractAddress;
+
+      if (!oracleAddress) {
+        throw new Error("Failed to get deployed contract address");
+      }
+
+      notification.success(`SimpleOracle deployed at: ${oracleAddress}`);
+
+      // Step 2: Add oracle to whitelist
+      await writeWhitelistOracle({
+        functionName: "addOracle",
+        args: [oracleAddress],
+      });
+
+      notification.success("Oracle successfully added to whitelist!");
+
+      // Step 3: Set initial price on the newly deployed oracle
+      const priceInWei = parseEther(initialPrice);
+
+      const setPriceTxHash = await walletClient.writeContract({
+        address: oracleAddress,
+        abi: simpleOracleAbi,
+        functionName: "setPrice",
+        args: [priceInWei],
+      });
+
+      await publicClient.waitForTransactionReceipt({
+        hash: setPriceTxHash,
+      });
+
+      // Reset form and close modal
+      setNewOracleOwner(undefined);
+      setInitialPrice("");
+    } catch (error: any) {
+      console.log("Error adding oracle:", error);
+      notification.error(`Failed to add oracle: ${getParsedError(error)}`);
+    } finally {
+      setIsDeploying(false);
+    }
+  };
+
+  const resetAndCloseModal = () => {
+    setNewOracleOwner(undefined);
+    setInitialPrice("");
+  };
+
+  return (
+    <>
+      {/* Add Oracle Button */}
+      <div>
+        <label htmlFor="add-oracle-modal" className="btn btn-primary btn-sm font-normal gap-1">
+          <PlusIcon className="h-4 w-4" />
+          <span>Add Oracle Node</span>
+        </label>
+      </div>
+
+      <input type="checkbox" id="add-oracle-modal" className="modal-toggle" />
+
+      {/* Modal Dialog */}
+      <label htmlFor="add-oracle-modal" className="modal cursor-pointer">
+        <label className="modal-box relative">
+          {/* dummy input to capture event onclick on modal box */}
+          <input className="h-0 w-0 absolute top-0 left-0" />
+          <h3 className="font-bold text-lg mb-4">Add New Oracle</h3>
+          <label htmlFor="add-oracle-modal" className="btn btn-ghost btn-sm btn-circle absolute right-3 top-3">
+            ✕
+          </label>
+          <div className="flex flex-col gap-4">
+            <div>
+              <p className="block text-sm font-medium mb-2">Oracle Owner Address</p>
+              <div className="flex gap-2">
+                <div className="flex-1">
+                  <AddressInput
+                    placeholder="Enter oracle owner address"
+                    value={newOracleOwner ?? ""}
+                    onChange={setNewOracleOwner}
+                  />
+                </div>
+                <button
+                  type="button"
+                  className="btn btn-secondary btn-sm"
+                  onClick={handleGenerateRandomAddress}
+                  disabled={isDeploying}
+                >
+                  🎲 Random
+                </button>
+              </div>
+            </div>
+
+            <div>
+              <p className="block text-sm font-medium mb-2">Initial Price (USD)</p>
+              <IntegerInput
+                placeholder="Enter initial price"
+                value={initialPrice}
+                onChange={setInitialPrice}
+                disableMultiplyBy1e18={true}
+              />
+            </div>
+          </div>
+
+          <div className="modal-action">
+            <button className="btn btn-ghost" onClick={resetAndCloseModal} disabled={isDeploying}>
+              Cancel
+            </button>
+            <button
+              className="btn btn-primary"
+              onClick={handleAddOracle}
+              disabled={!newOracleOwner || !initialPrice || isDeploying}
+            >
+              {isDeploying ? (
+                <>
+                  <span className="loading loading-spinner loading-sm"></span>
+                  Deploying...
+                </>
+              ) : (
+                "Deploy"
+              )}
+            </button>
+          </div>
+        </label>
+      </label>
+    </>
+  );
+};

--- a/packages/nextjs/components/oracle/whitelist/WhitelistRow.tsx
+++ b/packages/nextjs/components/oracle/whitelist/WhitelistRow.tsx
@@ -1,16 +1,16 @@
 import { formatEther } from "viem";
+import { useReadContract } from "wagmi";
 import { HighlightedCell } from "~~/components/oracle/HighlightedCell";
 import { NodeRowProps } from "~~/components/oracle/types";
 import { Address } from "~~/components/scaffold-eth";
-import { useScaffoldReadContract } from "~~/hooks/scaffold-eth";
-import { ContractName } from "~~/utils/scaffold-eth/contract";
+import deployedContracts from "~~/contracts/deployedContracts";
 
-export const WhitelistRow = ({ address, index }: NodeRowProps) => {
-  const contractNameSuffix = index !== undefined && index > 0 ? `_${index + 1}` : "";
-  const contractName = `SimpleOracle${contractNameSuffix}` as ContractName;
+export const WhitelistRow = ({ address }: NodeRowProps) => {
+  const simpleOracleAbi = deployedContracts[31337].SimpleOracle_1.abi; // TODO: fix this. Maybe put it in a separate file as a constant.
 
-  const { data } = useScaffoldReadContract({
-    contractName: contractName,
+  const { data } = useReadContract({
+    address: address,
+    abi: simpleOracleAbi,
     functionName: "getPrice",
   });
 

--- a/packages/nextjs/components/oracle/whitelist/WhitelistTable.tsx
+++ b/packages/nextjs/components/oracle/whitelist/WhitelistTable.tsx
@@ -1,4 +1,5 @@
 import TooltipInfo from "~~/components/TooltipInfo";
+import { AddOracleButton } from "~~/components/oracle/whitelist/AddOracleButton";
 import { WhitelistRow } from "~~/components/oracle/whitelist/WhitelistRow";
 import { useScaffoldEventHistory } from "~~/hooks/scaffold-eth";
 
@@ -33,12 +34,14 @@ export const WhitelistTable = () => {
     contractName: "WhitelistOracle",
     eventName: "OracleAdded",
     fromBlock: 0n,
+    watch: true,
   });
 
   const { data: oraclesRemoved, isLoading: isLoadingOraclesRemoved } = useScaffoldEventHistory({
     contractName: "WhitelistOracle",
     eventName: "OracleRemoved",
     fromBlock: 0n,
+    watch: true,
   });
 
   const isLoading = isLoadingOraclesAdded || isLoadingOraclesRemoved;
@@ -50,7 +53,10 @@ export const WhitelistTable = () => {
 
   return (
     <div className="flex flex-col gap-2">
-      <h2 className="text-xl font-bold">Oracle Nodes</h2>
+      <div className="flex gap-2 justify-between">
+        <h2 className="text-xl font-bold">Oracle Nodes</h2>
+        <AddOracleButton />
+      </div>
       <div className="bg-base-100 rounded-lg p-4 relative">
         <TooltipInfo top={0} right={0} infoText="TODO: Update this tooltip" />
         <div className="overflow-x-auto">

--- a/packages/nextjs/contracts/deployedContracts.ts
+++ b/packages/nextjs/contracts/deployedContracts.ts
@@ -1007,7 +1007,7 @@ const deployedContracts = {
       inheritedFunctions: {},
     },
     StakingOracle: {
-      address: "0x0DCd1Bf9A1b36cE34237eEaFef220932846BCD82",
+      address: "0x9A676e781A523b5d0C0e43731313A708CB607508",
       abi: [
         {
           inputs: [],
@@ -1358,6 +1358,19 @@ const deployedContracts = {
             },
           ],
           name: "removeOracle",
+          outputs: [],
+          stateMutability: "nonpayable",
+          type: "function",
+        },
+        {
+          inputs: [
+            {
+              internalType: "address",
+              name: "newOwner",
+              type: "address",
+            },
+          ],
+          name: "transferOwnership",
           outputs: [],
           stateMutability: "nonpayable",
           type: "function",


### PR DESCRIPTION
#28 
To make it work:
- I removed the onlyowner modifier from the SimpleOracle
- Added transferOwnership to whitelist oracle, because I need to make the owner my burner wallet to be able to addOracle. Also, passing the burner wallet address in the beginning is not an option, because deployer is also adding 10 oracles in the beginning. Also, the user needs to set the burner wallet's address in the deployer contract.
- In the WhitelistRow, I had to use useReadContract from wagmi, because when we deploy the contract from UI, it is not in the deployed contracts, so it is easier to get it by address.
- 


https://github.com/user-attachments/assets/38a70837-9b6a-44be-bd10-4ac2248eebc2

If you think that this feature changes many things and adds inconveniences for the students (like setting the address in deploy script), then maybe it is not worth adding this feature. Maybe I need to remove onlyOwner modifier for whitelistOracle as well, so there is no need to set the address in deployer script for students? Please let me know what do you think?