### PR TITLE
Explain color highlighting

### DIFF
--- a/packages/hardhat/contracts/StakingOracle.sol
+++ b/packages/hardhat/contracts/StakingOracle.sol
@@ -129,7 +129,7 @@ contract StakingOracle {
 
     function separateStaleNodes(
         address[] memory nodesToSeparate
-    ) internal view returns (address[] memory fresh, address[] memory stale) {
+    ) public view returns (address[] memory fresh, address[] memory stale) {
         address[] memory freshNodeAddresses = new address[](nodesToSeparate.length);
         address[] memory staleNodeAddresses = new address[](nodesToSeparate.length);
         uint256 freshCount = 0;

--- a/packages/nextjs/components/TooltipInfo.tsx
+++ b/packages/nextjs/components/TooltipInfo.tsx
@@ -5,17 +5,18 @@ interface TooltipInfoProps {
   top?: number;
   right?: number;
   infoText: string;
-  direction?: "left" | "right" | "top" | "bottom";
+  className?: string;
 }
 
 // Note: The relative positioning is required for the tooltip to work.
-const TooltipInfo: React.FC<TooltipInfoProps> = ({ top, right, infoText, direction = "right" }) => {
-  const tooltipDirectionClass = `tooltip-${direction}`;
+const TooltipInfo: React.FC<TooltipInfoProps> = ({ top, right, infoText, className = "" }) => {
+  const baseClasses = "tooltip tooltip-secondary font-normal";
+  const tooltipClasses = className ? `${baseClasses} ${className}` : `${baseClasses} tooltip-right`;
 
   if (top !== undefined && right !== undefined) {
     return (
       <span className="absolute z-10" style={{ top: `${top * 0.25}rem`, right: `${right * 0.25}rem` }}>
-        <div className={`tooltip tooltip-secondary ${tooltipDirectionClass} font-normal`} data-tip={infoText}>
+        <div className={tooltipClasses} data-tip={infoText}>
           <QuestionMarkCircleIcon className="h-5 w-5 m-1" />
         </div>
       </span>
@@ -23,7 +24,7 @@ const TooltipInfo: React.FC<TooltipInfoProps> = ({ top, right, infoText, directi
   }
 
   return (
-    <div className={`tooltip tooltip-secondary ${tooltipDirectionClass} font-normal`} data-tip={infoText}>
+    <div className={tooltipClasses} data-tip={infoText}>
       <QuestionMarkCircleIcon className="h-5 w-5 m-1" />
     </div>
   );

--- a/packages/nextjs/components/TooltipInfo.tsx
+++ b/packages/nextjs/components/TooltipInfo.tsx
@@ -12,16 +12,16 @@ const TooltipInfo: React.FC<TooltipInfoProps> = ({ top, right, infoText }) => {
   if (top !== undefined && right !== undefined) {
     return (
       <span className="absolute z-10" style={{ top: `${top * 0.25}rem`, right: `${right * 0.25}rem` }}>
-        <div className="tooltip tooltip-secondary tooltip-right" data-tip={infoText}>
-          <QuestionMarkCircleIcon className="h-5 w-5" />
+        <div className="tooltip tooltip-secondary tooltip-right font-normal" data-tip={infoText}>
+          <QuestionMarkCircleIcon className="h-5 w-5 m-1" />
         </div>
       </span>
     );
   }
 
   return (
-    <div className="tooltip tooltip-secondary tooltip-right" data-tip={infoText}>
-      <QuestionMarkCircleIcon className="h-5 w-5" />
+    <div className="tooltip tooltip-secondary tooltip-right font-normal" data-tip={infoText}>
+      <QuestionMarkCircleIcon className="h-5 w-5 m-1" />
     </div>
   );
 };

--- a/packages/nextjs/components/TooltipInfo.tsx
+++ b/packages/nextjs/components/TooltipInfo.tsx
@@ -2,19 +2,27 @@ import React from "react";
 import { QuestionMarkCircleIcon } from "@heroicons/react/24/outline";
 
 interface TooltipInfoProps {
-  top: number;
-  right: number;
+  top?: number;
+  right?: number;
   infoText: string;
 }
 
 // Note: The relative positioning is required for the tooltip to work.
 const TooltipInfo: React.FC<TooltipInfoProps> = ({ top, right, infoText }) => {
+  if (top !== undefined && right !== undefined) {
+    return (
+      <span className="absolute z-10" style={{ top: `${top * 0.25}rem`, right: `${right * 0.25}rem` }}>
+        <div className="tooltip tooltip-secondary tooltip-right" data-tip={infoText}>
+          <QuestionMarkCircleIcon className="h-5 w-5" />
+        </div>
+      </span>
+    );
+  }
+
   return (
-    <span className="absolute z-10" style={{ top: `${top * 0.25}rem`, right: `${right * 0.25}rem` }}>
-      <div className="tooltip tooltip-secondary tooltip-left" data-tip={infoText}>
-        <QuestionMarkCircleIcon className="h-5 w-5" />
-      </div>
-    </span>
+    <div className="tooltip tooltip-secondary tooltip-right" data-tip={infoText}>
+      <QuestionMarkCircleIcon className="h-5 w-5" />
+    </div>
   );
 };
 

--- a/packages/nextjs/components/TooltipInfo.tsx
+++ b/packages/nextjs/components/TooltipInfo.tsx
@@ -5,14 +5,17 @@ interface TooltipInfoProps {
   top?: number;
   right?: number;
   infoText: string;
+  direction?: "left" | "right" | "top" | "bottom";
 }
 
 // Note: The relative positioning is required for the tooltip to work.
-const TooltipInfo: React.FC<TooltipInfoProps> = ({ top, right, infoText }) => {
+const TooltipInfo: React.FC<TooltipInfoProps> = ({ top, right, infoText, direction = "right" }) => {
+  const tooltipDirectionClass = `tooltip-${direction}`;
+
   if (top !== undefined && right !== undefined) {
     return (
       <span className="absolute z-10" style={{ top: `${top * 0.25}rem`, right: `${right * 0.25}rem` }}>
-        <div className="tooltip tooltip-secondary tooltip-right font-normal" data-tip={infoText}>
+        <div className={`tooltip tooltip-secondary ${tooltipDirectionClass} font-normal`} data-tip={infoText}>
           <QuestionMarkCircleIcon className="h-5 w-5 m-1" />
         </div>
       </span>
@@ -20,7 +23,7 @@ const TooltipInfo: React.FC<TooltipInfoProps> = ({ top, right, infoText }) => {
   }
 
   return (
-    <div className="tooltip tooltip-secondary tooltip-right font-normal" data-tip={infoText}>
+    <div className={`tooltip tooltip-secondary ${tooltipDirectionClass} font-normal`} data-tip={infoText}>
       <QuestionMarkCircleIcon className="h-5 w-5 m-1" />
     </div>
   );

--- a/packages/nextjs/components/oracle/NodeRow.tsx
+++ b/packages/nextjs/components/oracle/NodeRow.tsx
@@ -8,7 +8,7 @@ import { Address } from "~~/components/scaffold-eth";
 import { useScaffoldReadContract } from "~~/hooks/scaffold-eth";
 import { getHighlightColorForPrice } from "~~/utils/scaffold-eth/common";
 
-export const NodeRow = ({ address }: NodeRowProps) => {
+export const NodeRow = ({ address, isStale }: NodeRowProps) => {
   const { data = [] } = useScaffoldReadContract({
     contractName: "StakingOracle",
     functionName: "nodes",
@@ -87,6 +87,7 @@ export const NodeRow = ({ address }: NodeRowProps) => {
       <HighlightedCell
         value={lastReportedPriceFormatted}
         highlightColor={getHighlightColorForPrice(lastReportedPrice, medianPrice)}
+        className={isStale ? "opacity-40" : ""}
       >
         {lastReportedPriceFormatted}
       </HighlightedCell>

--- a/packages/nextjs/components/oracle/NodesTable.tsx
+++ b/packages/nextjs/components/oracle/NodesTable.tsx
@@ -43,8 +43,17 @@ export const NodesTable = () => {
     functionName: "getNodeAddresses",
   });
 
+  const { data: staleNodesData } = useScaffoldReadContract({
+    contractName: "StakingOracle",
+    functionName: "separateStaleNodes",
+    args: [nodeAddresses || []],
+  });
+
   const tooltipText =
     "This table displays registered oracle nodes that provide price data to the system. Nodes are displayed as inactive if they don't have enough ETH staked. You can edit the skip probability and price variance of an oracle node with the slider.";
+
+  // Extract stale node addresses from the returned data
+  const staleNodeAddresses = staleNodesData?.[1] || [];
 
   return (
     <div className="flex flex-col gap-2">
@@ -63,19 +72,19 @@ export const NodesTable = () => {
                 <th>
                   <div className="flex items-center gap-1">
                     Staked Amount (ETH)
-                    <TooltipInfo infoText="Red highlighting indicates a slashing event" />
+                    <TooltipInfo infoText="Red shows slashing event" />
                   </div>
                 </th>
                 <th>
                   <div className="flex items-center gap-1">
                     Last Reported Price (USD)
-                    <TooltipInfo infoText="Color highlighting shows how close the reported price is to the median price across all nodes" />
+                    <TooltipInfo infoText="Color shows proximity to median price" />
                   </div>
                 </th>
                 <th>
                   <div className="flex items-center gap-1">
                     ORA Balance
-                    <TooltipInfo infoText="Green highlighting indicates positive ORA token balance" />
+                    <TooltipInfo infoText="Green shows positive balance" />
                   </div>
                 </th>
                 <th>Skip Probability</th>
@@ -89,7 +98,7 @@ export const NodesTable = () => {
                 <NoNodesRow />
               ) : (
                 nodeAddresses?.map((address: string, index: number) => (
-                  <NodeRow key={index} index={index} address={address} />
+                  <NodeRow key={index} index={index} address={address} isStale={staleNodeAddresses.includes(address)} />
                 ))
               )}
             </tbody>

--- a/packages/nextjs/components/oracle/NodesTable.tsx
+++ b/packages/nextjs/components/oracle/NodesTable.tsx
@@ -48,9 +48,13 @@ export const NodesTable = () => {
 
   return (
     <div className="flex flex-col gap-2">
-      <h2 className="text-xl font-bold">Oracle Nodes</h2>
+      <div className="flex items-center gap-2">
+        <h2 className="text-xl font-bold">Oracle Nodes</h2>
+        <div className="mt-1">
+          <TooltipInfo infoText={tooltipText} />
+        </div>
+      </div>
       <div className="bg-base-100 rounded-lg p-4 relative">
-        <TooltipInfo top={0} right={0} infoText={tooltipText} />
         <div className="overflow-x-auto">
           <table className="table w-full">
             <thead>

--- a/packages/nextjs/components/oracle/NodesTable.tsx
+++ b/packages/nextjs/components/oracle/NodesTable.tsx
@@ -50,9 +50,9 @@ export const NodesTable = () => {
     <div className="flex flex-col gap-2">
       <div className="flex items-center gap-2">
         <h2 className="text-xl font-bold">Oracle Nodes</h2>
-        <div className="mt-1">
+        <span>
           <TooltipInfo infoText={tooltipText} />
-        </div>
+        </span>
       </div>
       <div className="bg-base-100 rounded-lg p-4 relative">
         <div className="overflow-x-auto">
@@ -60,9 +60,24 @@ export const NodesTable = () => {
             <thead>
               <tr>
                 <th>Node Address</th>
-                <th>Staked Amount (ETH)</th>
-                <th>Last Reported Price (USD)</th>
-                <th>ORA Balance</th>
+                <th>
+                  <div className="flex items-center gap-1">
+                    Staked Amount (ETH)
+                    <TooltipInfo infoText="Red highlighting indicates a slashing event" />
+                  </div>
+                </th>
+                <th>
+                  <div className="flex items-center gap-1">
+                    Last Reported Price (USD)
+                    <TooltipInfo infoText="Color highlighting shows how close the reported price is to the median price across all nodes" />
+                  </div>
+                </th>
+                <th>
+                  <div className="flex items-center gap-1">
+                    ORA Balance
+                    <TooltipInfo infoText="Green highlighting indicates positive ORA token balance" />
+                  </div>
+                </th>
                 <th>Skip Probability</th>
                 <th>Price Variance</th>
               </tr>

--- a/packages/nextjs/components/oracle/PriceWidget.tsx
+++ b/packages/nextjs/components/oracle/PriceWidget.tsx
@@ -51,7 +51,7 @@ export const PriceWidget = ({ contractName }: PriceWidgetProps) => {
         <TooltipInfo
           top={0}
           right={0}
-          infoText="Displays the median price. If no oracle nodes have reported prices in the last 10 seconds, it will display 'No fresh price'."
+          infoText="Displays the median price. If no oracle nodes have reported prices in the last 10 seconds, it will display 'No fresh price'. Color highlighting indicates how big of a change there was in the price."
         />
         <div className={`rounded-lg transition-colors duration-1000 ${highlight ? highlightColor : ""}`}>
           <div className="font-bold h-10 text-4xl flex items-center justify-center">

--- a/packages/nextjs/components/oracle/PriceWidget.tsx
+++ b/packages/nextjs/components/oracle/PriceWidget.tsx
@@ -6,10 +6,10 @@ import { useScaffoldReadContract } from "~~/hooks/scaffold-eth";
 const getHighlightColor = (oldPrice: bigint | undefined, newPrice: bigint | undefined): string => {
   if (oldPrice === undefined || newPrice === undefined) return "";
 
-  const change = Math.abs(Number(newPrice) - Number(oldPrice));
+  const change = Math.abs(parseFloat(formatEther(newPrice)) - parseFloat(formatEther(oldPrice)));
 
-  if (change < 3) return "bg-success";
-  if (change < 10) return "bg-warning";
+  if (change < 50) return "bg-success";
+  if (change < 100) return "bg-warning";
   return "bg-error";
 };
 

--- a/packages/nextjs/components/oracle/optimistic/SubmitAssertionButton.tsx
+++ b/packages/nextjs/components/oracle/optimistic/SubmitAssertionButton.tsx
@@ -124,7 +124,7 @@ const SubmitAssertionModal = ({ isOpen, onClose }: SubmitAssertionModalProps) =>
             <TooltipInfo
               top={-2}
               right={5}
-              direction="left"
+              className="tooltip-left"
               infoText="Create a new assertion with your reward stake. Leave time inputs blank to use default values."
             />
           </div>

--- a/packages/nextjs/components/oracle/optimistic/SubmitAssertionButton.tsx
+++ b/packages/nextjs/components/oracle/optimistic/SubmitAssertionButton.tsx
@@ -124,6 +124,7 @@ const SubmitAssertionModal = ({ isOpen, onClose }: SubmitAssertionModalProps) =>
             <TooltipInfo
               top={-2}
               right={5}
+              direction="left"
               infoText="Create a new assertion with your reward stake. Leave time inputs blank to use default values."
             />
           </div>

--- a/packages/nextjs/components/oracle/types.ts
+++ b/packages/nextjs/components/oracle/types.ts
@@ -1,6 +1,7 @@
 export interface NodeRowProps {
   address: string;
   index: number;
+  isStale?: boolean;
 }
 
 export interface WhitelistRowProps extends NodeRowProps {

--- a/packages/nextjs/components/oracle/whitelist/WhitelistTable.tsx
+++ b/packages/nextjs/components/oracle/whitelist/WhitelistTable.tsx
@@ -66,7 +66,7 @@ export const WhitelistTable = () => {
         <div className="flex items-center gap-2">
           <h2 className="text-xl font-bold">Oracle Nodes</h2>
           <span className="text-sm text-gray-500">
-            <TooltipInfo infoText={tooltipText} />
+            <TooltipInfo infoText={tooltipText} className="tooltip-right" />
           </span>
         </div>
         <div className="flex gap-2">

--- a/packages/nextjs/components/oracle/whitelist/WhitelistTable.tsx
+++ b/packages/nextjs/components/oracle/whitelist/WhitelistTable.tsx
@@ -79,7 +79,12 @@ export const WhitelistTable = () => {
             <thead>
               <tr>
                 <th>Node Address</th>
-                <th>Last Reported Price (USD)</th>
+                <th>
+                  <div className="flex items-center gap-1">
+                    Last Reported Price (USD)
+                    <TooltipInfo infoText="Color shows proximity to median price" />
+                  </div>
+                </th>
                 <th>Last Reported Time</th>
               </tr>
             </thead>

--- a/packages/nextjs/components/oracle/whitelist/WhitelistTable.tsx
+++ b/packages/nextjs/components/oracle/whitelist/WhitelistTable.tsx
@@ -63,13 +63,17 @@ export const WhitelistTable = () => {
   return (
     <div className="flex flex-col gap-2">
       <div className="flex gap-2 justify-between">
-        <h2 className="text-xl font-bold">Oracle Nodes</h2>
+        <div className="flex items-center gap-2">
+          <h2 className="text-xl font-bold">Oracle Nodes</h2>
+          <span className="text-sm text-gray-500">
+            <TooltipInfo infoText={tooltipText} />
+          </span>
+        </div>
         <div className="flex gap-2">
           <AddOracleButton />
         </div>
       </div>
       <div className="bg-base-100 rounded-lg p-4 relative">
-        <TooltipInfo top={0} right={0} infoText={tooltipText} />
         <div className="overflow-x-auto">
           <table className="table w-full">
             <thead>


### PR DESCRIPTION
Closes #53 

<img width="1603" height="449" alt="image" src="https://github.com/user-attachments/assets/993d0070-afa1-4304-91ba-cee8f36cae74" />

### Changes
- Moves the Staking tab table tooltip (say that 5 times fast!) next to the "Oracle Nodes" header. Does the same on the Whitelist tab
- Adds 3 tooltips to describe the meaning of the color highlighting that happens while running the simulation script
- Turns the price report cell gray when stale on the Staking tab